### PR TITLE
Create first unit test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ proc-macro = true
 [dependencies]
 syn = "0.15.26"
 quote = "0.6.3"
+proc-macro2 = "0.4"
 
 [dev-dependencies]
 rocket = "0.4.0"


### PR DESCRIPTION
# Content
This PR adds a first positive unit test case to the crate. In order to make the library unit testable we wrap the derive macro using proc_macro2.

The test is rather fragile and it would be desirable to assert the structure of the derived in less detail, but for now, it is not clear how to do it. Thus
 - we only have one simple example and assert the desired output
 - we have to exclude parts of the test data from formatting with formatting because rustfmt does not leave the token stream unchanged.

# Help needed
Any idea how to make the tests less fragile is welcome.